### PR TITLE
Fix "Song not available" error

### DIFF
--- a/ext/src/main/java/dev/brahmkshatriya/echo/extension/api/DeezerMedia.kt
+++ b/ext/src/main/java/dev/brahmkshatriya/echo/extension/api/DeezerMedia.kt
@@ -80,6 +80,14 @@ class DeezerMedia(private val deezerApi: DeezerApi, private val clientNP: OkHttp
         val response = clientNP.newCall(request).await()
         val responseBody = response.body.string()
 
+        // If the service is currently unavailable, go back to deezer
+        if (responseBody.contains("All accounts are cooling down")) {
+            return deezerApi.getMP3MediaUrl(
+                track,
+                quality == "128"
+            )
+        }
+
         return deezerApi.decodeJson(responseBody)
     }
 }


### PR DESCRIPTION
The error "Song not available" may occur due to different reasons.

- The server that returns the link for 320/FLAC songs may be overloaded ("All accounts are cooling down")
  - If the server is overloaded, no JSON is sent back and only the text message "All accounts are cooling down", which causes an JSON parse error.
- The track token that is saved with the track may be wrong
  - For some songs, the track token from a playlist or similar will not work (at least with a non premium account)
  - This can be solved by requesting the specific track again and using this track token instead of the previous one

This PR solves those two issues.

In my case, this worked for all songs that previously did not work.
I have not tested this with a premium account as I don't have one.